### PR TITLE
"あ"の時のエラー対処

### DIFF
--- a/c/mimori-tool2.c
+++ b/c/mimori-tool2.c
@@ -180,8 +180,6 @@ int makeSuzuko(char *arg_str, int arg_num){
 	char *str = arg_str;
 	int byte = 0;
 
-	if(arg_num == 0) return -1;
-
 	strcpy(str,hiraganaList[arg_num]);
 	byte += 3;
 	str += 3;

--- a/c/mimori-tool2.c
+++ b/c/mimori-tool2.c
@@ -180,6 +180,8 @@ int makeSuzuko(char *arg_str, int arg_num){
 	char *str = arg_str;
 	int byte = 0;
 
+	if(arg_num < 0) return -1;
+
 	strcpy(str,hiraganaList[arg_num]);
 	byte += 3;
 	str += 3;

--- a/python/mimoritool.py
+++ b/python/mimoritool.py
@@ -52,7 +52,7 @@ def makeMori(arg_num):
 
 
 def makeSuzuko(arg_num):
-	num = (arg_num % 46) + 9
+	num = (arg_num +9 ) % 46
 	suzuko = f'{hiraganaList[num] * 2}\u3099こ'
 
 	return suzuko


### PR DESCRIPTION
- pythonバージョンではnumが46を超えてしまう場合があるので変更しました. 

- C言語バージョンでは「ああ゙こ」と表示される際(具体的にはarg_numが0), 正しく表示されず, 「すずこ製造に失敗」となっていました. `makeSuzuko関数のif文を削除することで対応しました. `
